### PR TITLE
update jekyll dependency to 2.0

### DIFF
--- a/japr.gemspec
+++ b/japr.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version   = '>= 1.9.3'
 
   # Runtime dependencies
-  s.add_runtime_dependency 'jekyll', '~> 1.1'
+  s.add_runtime_dependency 'jekyll', '~> 2.0'
   s.add_runtime_dependency 'liquid', '~> 2.4'
 
   # Development dependencies


### PR DESCRIPTION
Didn't touch the gem version because I'm not sure if you want to make this a breaking change, or perhaps instead use `s.add_runtime_dependency 'jekyll', '>= 1.1'`

Still works fine in 2.0.2
