### PR TITLE
change asset pipeline to not be built in source

### DIFF
--- a/lib/japr.rb
+++ b/lib/japr.rb
@@ -46,7 +46,7 @@ module JAPR
   DEFAULTS = {
     'output_path'   => 'assets',
     'display_path'  => nil,
-    'staging_path'  => '.asset_pipeline',
+    'staging_path'  => '../.asset_pipeline',
     'bundle'        => true,
     'compress'      => true,
     'gzip'          => false


### PR DESCRIPTION
When the `.asset_pipeline` is built in source, jekyll serve with the watch option (`-w`) goes into an infinite rebuild loop in my setup on OSX for [this site](https://github.com/stdio-ghana/stdio-ghana.github.io) (sorry I don't have a smaller example).

Moving where .asset_pipeline is created seems the simplest solution.  There's probably a better one hooking into the watch process, but I'm not familiar enough w/ Ruby + Jekyll to do that.
