### PR TITLE
Update the rake dependency to 12.0

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,4 +7,5 @@ Rake::TestTask.new(:test) do |test|
   test.libs << 'spec'
   test.pattern = 'spec/**/*_spec.rb'
   test.verbose = false
+  test.warning = false
 end

--- a/japr.gemspec
+++ b/japr.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
 
   # Development dependencies
   s.add_development_dependency 'minitest', '~> 5.2'
-  s.add_development_dependency 'rake', '~> 10.0'
+  s.add_development_dependency 'rake', '~> 12.0'
 
   # Files
   s.files = Dir['lib/**/*.rb', 'LICENSE', 'README.md', 'CHANGELOG.md'].to_a


### PR DESCRIPTION
Besides updating rake, warnings had to be disabled to revert to the previous way of working (prior to rake version 12 I believe). Otherwise we would get a ton of method redefined warnings as our gem relies on monkey patching Liquid and Jekyll.

Fixes #35